### PR TITLE
CI: Don"t let analytics tank Lighthouse

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,9 +22,13 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build
+        env:
+          NEXT_PUBLIC_ENABLE_ANALYTICS: "0"
         run: yarn build
 
       - name: Start server
+        env:
+          NEXT_PUBLIC_ENABLE_ANALYTICS: "0"
         run: |
           yarn start --port 3000 &
           echo $! > /tmp/next_pid
@@ -34,6 +38,10 @@ jobs:
 
       - name: Run Lighthouse
         uses: treosh/lighthouse-ci-action@v12
+        env:
+          # Disable analytics scripts during Lighthouse runs to avoid skewing scores
+          # (and to prevent any non-Vercel 404 noise).
+          NEXT_PUBLIC_ENABLE_ANALYTICS: "0"
         with:
           urls: |
             http://127.0.0.1:3000/

--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,7 +1,13 @@
 export const GA_TRACKING_ID = 'G-SJ7CGBNE6Y'
 
+export const analyticsEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === '1'
+
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url) => {
+  if (!analyticsEnabled) return
+  if (!window.gtag) return
+
   window.gtag('config', GA_TRACKING_ID, {
     page_path: url,
   })
@@ -9,6 +15,9 @@ export const pageview = (url) => {
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 export const event = ({ action, category, label, value }) => {
+  if (!analyticsEnabled) return
+  if (!window.gtag) return
+
   window.gtag('event', action, {
     event_category: category,
     event_label: label,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,10 @@ import { useRouter } from 'next/router'
 import * as gtag from '../lib/gtag'
 import { Analytics } from '@vercel/analytics/react'
 
+const enableVercelAnalytics =
+  process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === '1' &&
+  Boolean(process.env.NEXT_PUBLIC_VERCEL_ENV)
+
 const App = ({ Component, pageProps }) => {
   const router = useRouter()
   useEffect(() => {
@@ -20,7 +24,7 @@ const App = ({ Component, pageProps }) => {
   return (
     <>
       <Component {...pageProps} />
-      <Analytics />
+      {enableVercelAnalytics ? <Analytics /> : null}
     </>
   )
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 
-import { GA_TRACKING_ID } from '../lib/gtag'
+import { GA_TRACKING_ID, analyticsEnabled } from '../lib/gtag'
 
 export default class MyDocument extends Document {
   render() {
@@ -8,13 +8,15 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
           {/* Global Site Tag (gtag.js) - Google Analytics */}
-          <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
-          />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
+          {analyticsEnabled ? (
+            <>
+              <script
+                async
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+              />
+              <script
+                dangerouslySetInnerHTML={{
+                  __html: `
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
@@ -22,8 +24,10 @@ export default class MyDocument extends Document {
               page_path: window.location.pathname,
             });
           `,
-            }}
-          />
+                }}
+              />
+            </>
+          ) : null}
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
The Lighthouse report shows main-thread/TBT penalties largely from analytics JS. Gate GA + Vercel Analytics behind NEXT_PUBLIC_ENABLE_ANALYTICS and set it to 0 in the Lighthouse workflow so CI scores reflect the site itself.