### PR TITLE
Make theme toggle subtle

### DIFF
--- a/components/dark-mode-toggle.tsx
+++ b/components/dark-mode-toggle.tsx
@@ -34,7 +34,7 @@ const DarkModeToggle = () => {
     <button
       type="button"
       onClick={toggleDarkMode}
-      className="fixed right-3 top-3 z-50 rounded-full border border-black/10 bg-white/70 px-2 py-1 text-xs text-gray-700 shadow-sm backdrop-blur transition hover:bg-white/90 dark:border-white/10 dark:bg-black/30 dark:text-gray-200 dark:hover:bg-black/40"
+      className="fixed right-3 top-3 z-50 rounded-full border border-black/10 bg-white/70 px-2 py-1 text-xs text-gray-700 shadow-sm backdrop-blur transition hover:bg-white/90 dark:border-white/10 dark:bg-black/20 dark:text-gray-100 dark:hover:bg-black/30"
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       title={isDark ? 'Light mode' : 'Dark mode'}
     >

--- a/components/dark-mode-toggle.tsx
+++ b/components/dark-mode-toggle.tsx
@@ -1,13 +1,12 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 const DarkModeToggle = () => {
   const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    // Check for saved theme preference or default to system preference
     const savedTheme = localStorage.getItem('theme')
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    
+
     if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
       setIsDark(true)
       document.documentElement.classList.add('dark')
@@ -18,40 +17,28 @@ const DarkModeToggle = () => {
   }, [])
 
   const toggleDarkMode = () => {
-    if (isDark) {
-      document.documentElement.classList.remove('dark')
-      localStorage.setItem('theme', 'light')
-      setIsDark(false)
-    } else {
+    const nextIsDark = !isDark
+
+    if (nextIsDark) {
       document.documentElement.classList.add('dark')
       localStorage.setItem('theme', 'dark')
-      setIsDark(true)
+    } else {
+      document.documentElement.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
     }
+
+    setIsDark(nextIsDark)
   }
 
   return (
     <button
+      type="button"
       onClick={toggleDarkMode}
-      className="fixed top-4 right-4 z-50 flex items-center space-x-1 bg-gray-200 dark:bg-gray-700 rounded-full p-2 transition-colors duration-200 hover:bg-gray-300 dark:hover:bg-gray-600"
-      aria-label="Toggle dark mode"
+      className="fixed right-3 top-3 z-50 rounded-full border border-black/10 bg-white/70 px-2 py-1 text-xs text-gray-700 shadow-sm backdrop-blur transition hover:bg-white/90 dark:border-white/10 dark:bg-black/30 dark:text-gray-200 dark:hover:bg-black/40"
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Light mode' : 'Dark mode'}
     >
-      <span 
-        className={`text-lg transition-opacity duration-200 ${isDark ? 'opacity-50' : 'opacity-100'}`}
-      >
-        ☀️
-      </span>
-      <div className="relative w-8 h-4">
-        <div 
-          className={`absolute top-0 left-0 w-4 h-4 bg-white rounded-full shadow-md transform transition-transform duration-200 ${
-            isDark ? 'translate-x-4' : 'translate-x-0'
-          }`}
-        />
-      </div>
-      <span 
-        className={`text-lg transition-opacity duration-200 ${isDark ? 'opacity-100' : 'opacity-50'}`}
-      >
-        🌙
-      </span>
+      {isDark ? '☾' : '☀'}
     </button>
   )
 }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -10,7 +10,7 @@ const Layout = ({ preview, children }: Props) => {
   return (
     <>
       <Meta />
-      <div className="min-h-screen bg-white dark:bg-olive-900 transition-colors duration-200">
+      <div className="min-h-screen bg-white text-gray-900 dark:bg-olive-900 dark:text-gray-100 transition-colors duration-200">
         <DarkModeToggle />
         <main className="w-full">{children}</main>
       </div>


### PR DESCRIPTION
Replaces the oversized dark/light toggle with a single subtle icon button (fixed top-right) that will not cover page content on mobile.