### PR TITLE
CI: Lighthouse on Vercel preview URLs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,41 +10,67 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
 
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: read
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: yarn
-
-      - name: Install
-        run: yarn install --frozen-lockfile
-
-      - name: Build
-        run: yarn build
-
-      - name: Start server
+      - name: Wait for Vercel deployment + get URL
+        id: vercel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Vercel typically uses these environment names on GitHub deployments.
+          # We'll prefer Preview for PRs, Production for pushes to main.
+          ENVIRONMENT: ${{ github.event_name == 'pull_request' && 'Preview' || 'Production' }}
         run: |
-          yarn start --port 3000 &
-          echo $! > /tmp/next_pid
+          echo "Waiting for Vercel deployment for $SHA ($ENVIRONMENT)"
 
-      - name: Wait for server
-        run: npx wait-on@latest http://127.0.0.1:3000
+          # Poll deployments for this SHA until we find a deployment with a SUCCESS status.
+          # Up to ~10 minutes.
+          for i in $(seq 1 60); do
+            deployment_id=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$OWNER/$REPO/deployments?sha=$SHA&per_page=50" \
+              --jq ".[] | select(.environment == \"$ENVIRONMENT\") | .id" \
+              | head -n 1 || true)
 
-      - name: Run Lighthouse
+            if [ -n "$deployment_id" ]; then
+              status_json=$(gh api \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/$OWNER/$REPO/deployments/$deployment_id/statuses?per_page=10" \
+                --jq ".[0]" || true)
+
+              state=$(printf "%s" "$status_json" | jq -r ".state // empty")
+              target_url=$(printf "%s" "$status_json" | jq -r ".target_url // empty")
+
+              echo "Found deployment $deployment_id state=$state url=$target_url"
+
+              if [ "$state" = "success" ] && [ -n "$target_url" ]; then
+                # Normalize: strip trailing slash
+                target_url=${target_url%/}
+                echo "url=$target_url" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for Vercel deployment success for $SHA ($ENVIRONMENT)" >&2
+          exit 1
+
+      - name: Run Lighthouse against Vercel URL
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            http://127.0.0.1:3000/
-            http://127.0.0.1:3000/quotes
+            ${{ steps.vercel.outputs.url }}/
+            ${{ steps.vercel.outputs.url }}/quotes
           uploadArtifacts: true
           temporaryPublicStorage: true
           comment: true
-
-      - name: Stop server
-        if: always()
-        run: |
-          if [ -f /tmp/next_pid ]; then
-            kill $(cat /tmp/next_pid) || true
-          fi


### PR DESCRIPTION
Option B: wait for the Vercel deployment to succeed and run Lighthouse against the live Vercel Preview URL (and Production on main). Non-blocking; comments results.