### PR TITLE
Fix theme consistency + improve quotes mobile

### DIFF
--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,5 +1,9 @@
 import { ReactNode } from "react";
 
 export default function Container({ children }: { children: ReactNode }) {
-  return <div className="container mx-auto px-5 py-12 relative">{children}</div>
+  return (
+    <div className="container relative mx-auto px-5 py-8 sm:py-12">
+      {children}
+    </div>
+  )
 }

--- a/components/markdown-styles.module.css
+++ b/components/markdown-styles.module.css
@@ -4,47 +4,9 @@
   @apply text-lg leading-relaxed;
 }
 
-/* Force text colors with higher specificity */
-.markdown,
-.markdown *,
-.markdown p,
-.markdown div,
-.markdown span,
-.markdown ul,
-.markdown ol,
-.markdown li,
-.markdown h1,
-.markdown h2,
-.markdown h3,
-.markdown h4,
-.markdown h5,
-.markdown h6,
-.markdown strong,
-.markdown b,
-.markdown em,
-.markdown i {
-  color: #111827 !important; /* gray-900 */
-}
-
-:global(.dark) .markdown,
-:global(.dark) .markdown *,
-:global(.dark) .markdown p,
-:global(.dark) .markdown div,
-:global(.dark) .markdown span,
-:global(.dark) .markdown ul,
-:global(.dark) .markdown ol,
-:global(.dark) .markdown li,
-:global(.dark) .markdown h1,
-:global(.dark) .markdown h2,
-:global(.dark) .markdown h3,
-:global(.dark) .markdown h4,
-:global(.dark) .markdown h5,
-:global(.dark) .markdown h6,
-:global(.dark) .markdown strong,
-:global(.dark) .markdown b,
-:global(.dark) .markdown em,
-:global(.dark) .markdown i {
-  color: #f3f4f6 !important; /* gray-100 */
+/* Base text color should follow the theme without fighting Tailwind. */
+.markdown {
+  @apply text-gray-900 dark:text-gray-100;
 }
 
 /* Paragraph and list spacing */
@@ -93,44 +55,21 @@
 
 /* Links */
 .markdown a {
-  @apply underline;
-  color: #2563eb !important; /* blue-600 */
-}
-
-:global(.dark) .markdown a {
-  color: #60a5fa !important; /* blue-400 */
+  @apply underline text-blue-600 dark:text-blue-400;
 }
 
 /* Blockquotes */
 .markdown blockquote {
-  @apply border-l-4 border-gray-300 pl-4;
-  color: #374151 !important; /* gray-700 */
-}
-
-:global(.dark) .markdown blockquote {
-  @apply border-gray-600;
-  color: #d1d5db !important; /* gray-300 */
+  @apply border-l-4 border-gray-300 pl-4 text-gray-700 dark:border-gray-600 dark:text-gray-300;
 }
 
 /* Code */
 .markdown code {
-  @apply bg-gray-100 px-1 py-0.5 rounded text-sm;
-  color: #111827 !important; /* gray-900 */
-}
-
-:global(.dark) .markdown code {
-  @apply bg-gray-800;
-  color: #f3f4f6 !important; /* gray-100 */
+  @apply rounded bg-gray-100 px-1 py-0.5 text-sm text-gray-900 dark:bg-gray-800 dark:text-gray-100;
 }
 
 .markdown pre {
-  @apply bg-gray-100 p-4 rounded-lg overflow-x-auto;
-  color: #111827 !important; /* gray-900 */
-}
-
-:global(.dark) .markdown pre {
-  @apply bg-gray-800;
-  color: #f3f4f6 !important; /* gray-100 */
+  @apply overflow-x-auto rounded-lg bg-gray-100 p-4 text-gray-900 dark:bg-gray-800 dark:text-gray-100;
 }
 
 .markdown pre code {

--- a/pages/quotes.tsx
+++ b/pages/quotes.tsx
@@ -3,16 +3,19 @@ import Layout from "../components/layout";
 import Head from "next/head";
 import Link from "next/link";
 import PostHeader from "../components/post-header";
-import { useEffect, useState } from "react";
 import { getQuotesFromCSV, type QuoteRow } from "../lib/quotes";
 import { makeQuoteSlug } from "../lib/quote-slug";
 
 export async function getStaticProps() {
   const quotes = getQuotesFromCSV();
+  const featuredQuote = quotes.length
+    ? quotes[Math.floor(Math.random() * quotes.length)]
+    : null;
 
   return {
     props: {
       quotes,
+      featuredQuote,
     },
   };
 }
@@ -22,11 +25,11 @@ const QuoteCard = ({ id, quote, attribution }: QuoteRow) => {
 
   return (
     <Link href={`/quote/${slug}`} className="block">
-      <div className="mb-8 p-6">
-        <blockquote className="mb-3 text-lg italic leading-relaxed text-gray-800 dark:text-gray-100">
+      <div className="rounded-lg border border-black/5 bg-white/50 p-4 shadow-sm backdrop-blur transition hover:bg-white/70 dark:border-white/10 dark:bg-black/20 dark:hover:bg-black/25 sm:p-6">
+        <blockquote className="mb-2 text-base italic leading-relaxed text-gray-800 dark:text-gray-100 sm:text-lg">
           “{quote}”
         </blockquote>
-        <cite className="text-sm font-medium not-italic text-gray-600 dark:text-gray-400">
+        <cite className="text-sm font-medium not-italic text-gray-600 dark:text-gray-300">
           — {attribution || "Unknown"}
         </cite>
       </div>
@@ -34,60 +37,53 @@ const QuoteCard = ({ id, quote, attribution }: QuoteRow) => {
   );
 };
 
-export default function QuotesPage({ quotes }: { quotes: QuoteRow[] }) {
-  const [randomQuote, setRandomQuote] = useState<QuoteRow | null>(null);
-
-  useEffect(() => {
-    // Select a random quote for the top of the page on client side
-    if (quotes.length > 0) {
-      const selectedQuote = quotes[Math.floor(Math.random() * quotes.length)];
-      setRandomQuote(selectedQuote);
-    }
-  }, [quotes]);
-
+export default function QuotesPage({
+  quotes,
+  featuredQuote,
+}: {
+  quotes: QuoteRow[];
+  featuredQuote: QuoteRow | null;
+}) {
   return (
     <Layout>
       <Container>
-        
-          <>
-            <article>
-              <Head>
-                <title>Quotes</title>
-              </Head>
-              <PostHeader title="Quotes" />
-              <div className="max-w-2xl mx-auto">
-                {randomQuote && (
-                  <Link
-                    href={`/quote/${makeQuoteSlug({
-                      quote: randomQuote.quote,
-                      id: randomQuote.id,
-                      maxLen: 128,
-                    })}`}
-                    className="block"
-                  >
-                    <div className="mb-12 cursor-pointer text-center">
-                      <blockquote className="mb-4 text-2xl font-medium italic leading-relaxed text-gray-800 dark:text-gray-100">
-                        “{randomQuote.quote}”
-                      </blockquote>
-                      <cite className="text-lg font-semibold not-italic text-gray-600 dark:text-gray-300">
-                        — {randomQuote.attribution || "Unknown"}
-                      </cite>
-                    </div>
-                  </Link>
-                )}
-                <div className="space-y-6">
-                  {quotes.map((q) => (
-                    <QuoteCard
-                      key={q.id}
-                      id={q.id}
-                      quote={q.quote}
-                      attribution={q.attribution}
-                    />
-                  ))}
+        <article>
+          <Head>
+            <title>Quotes</title>
+          </Head>
+          <PostHeader title="Quotes" />
+          <div className="mx-auto max-w-2xl">
+            {featuredQuote && (
+              <Link
+                href={`/quote/${makeQuoteSlug({
+                  quote: featuredQuote.quote,
+                  id: featuredQuote.id,
+                  maxLen: 128,
+                })}`}
+                className="block"
+              >
+                <div className="mb-8 rounded-lg border border-black/5 bg-white/50 p-4 text-center shadow-sm backdrop-blur transition hover:bg-white/70 dark:border-white/10 dark:bg-black/20 dark:hover:bg-black/25 sm:mb-10 sm:p-6">
+                  <blockquote className="mb-3 text-xl font-medium italic leading-relaxed text-gray-800 dark:text-gray-100 sm:text-2xl">
+                    “{featuredQuote.quote}”
+                  </blockquote>
+                  <cite className="text-base font-semibold not-italic text-gray-600 dark:text-gray-300">
+                    — {featuredQuote.attribution || "Unknown"}
+                  </cite>
                 </div>
-              </div>
-            </article>
-          </>
+              </Link>
+            )}
+            <div className="space-y-4 sm:space-y-6">
+              {quotes.map((q) => (
+                <QuoteCard
+                  key={q.id}
+                  id={q.id}
+                  quote={q.quote}
+                  attribution={q.attribution}
+                />
+              ))}
+            </div>
+          </div>
+        </article>
       </Container>
     </Layout>
   );


### PR DESCRIPTION
Fixes inconsistent container/background/text colors on README + quotes pages by simplifying markdown CSS to follow the theme. Also improves /quotes mobile layout with card styling and removes client-side random quote (no CLS).